### PR TITLE
remove notify_remaining_rate_limit

### DIFF
--- a/lib/livestorm_api.rb
+++ b/lib/livestorm_api.rb
@@ -10,28 +10,25 @@ class LivestormApi
   # See: https://developers.livestorm.co/docs/rate-limits-and-quotas
   #
   #
-  ROOT_URL = "https://api.livestorm.co/v1"
-
-  def initialize(api_token:)
+  def initialize(api_token:, root_url: 'https://api.livestorm.co/v1')
     @api_token = api_token
+    @root_url = root_url
   end
 
   def get_ping
-    notify_remaining_ratelimit(RestClient.get("#{ROOT_URL}/ping", headers))
+    RestClient.get("#{root_url}/ping", headers)
   end
 
   def get_events(options = {})
     params = { params: options }
-    notify_remaining_ratelimit(
-      RestClient::Request.execute(method: :get, url: "#{ROOT_URL}/events", headers: headers.merge(params))
-    )
+    RestClient::Request.execute(method: :get, url: "#{root_url}/events", headers: headers.merge(params))
   end
 
   # requires an event Hash
   #
   def post_event(event)
     payload = { data: event }.to_json
-    notify_remaining_ratelimit(RestClient.post("#{ROOT_URL}/events", payload, headers))
+    RestClient.post("#{root_url}/events", payload, headers)
   end
 
   # requires an event Hash
@@ -39,93 +36,79 @@ class LivestormApi
   def patch_event(event)
     id = event.delete(:id)
     payload = { data: event }.to_json
-    notify_remaining_ratelimit(RestClient.patch("#{ROOT_URL}/events/#{id}", payload, headers))
+    RestClient.patch("#{root_url}/events/#{id}", payload, headers)
   end
 
   def get_event(livestorm_event_id)
-    notify_remaining_ratelimit(
-      RestClient.get("#{ROOT_URL}/events/#{livestorm_event_id}", headers)
-    )
+    RestClient.get("#{root_url}/events/#{livestorm_event_id}", headers)
   end
 
   def get_event_people(livestorm_event_id, options = {})
     params = { params: options }
-    notify_remaining_ratelimit(
-      RestClient::Request.execute(
-        method: :get,
-        url: "#{ROOT_URL}/events/#{livestorm_event_id}/people",
-        headers: headers.merge(params)
-      )
+    RestClient::Request.execute(
+      method: :get,
+      url: "#{root_url}/events/#{livestorm_event_id}/people",
+      headers: headers.merge(params)
     )
   end
 
   def get_event_person(livestorm_event_id:, livestorm_person_id:)
-    notify_remaining_ratelimit(
-      RestClient.get("#{ROOT_URL}/events/#{livestorm_event_id}/people/#{livestorm_person_id}", headers)
-    )
+    RestClient.get("#{root_url}/events/#{livestorm_event_id}/people/#{livestorm_person_id}", headers)
   end
 
   def get_event_sessions(livestorm_event_id, options = {})
     params = { params: options }
-    notify_remaining_ratelimit(
-      RestClient::Request.execute(
-        method: :get,
-        url: "#{ROOT_URL}/events/#{livestorm_event_id}/sessions",
-        headers: headers.merge(params)
-      )
+    RestClient::Request.execute(
+      method: :get,
+      url: "#{root_url}/events/#{livestorm_event_id}/sessions",
+      headers: headers.merge(params)
     )
   end
 
   def post_event_session(session_attrs)
     livestorm_event_id = session_attrs.delete(:livestorm_event_id)
     payload = { data: session_attrs }.to_json
-    notify_remaining_ratelimit(RestClient.post("#{ROOT_URL}/events/#{livestorm_event_id}/sessions", payload, headers))
+    RestClient.post("#{root_url}/events/#{livestorm_event_id}/sessions", payload, headers)
   end
 
   def patch_event_session(session_attrs)
     id = session_attrs.delete(:id)
     payload = { data: session_attrs }.to_json
-    notify_remaining_ratelimit(RestClient.patch("#{ROOT_URL}/sessions/#{id}", payload, headers))
+    RestClient.patch("#{root_url}/sessions/#{id}", payload, headers)
   end
 
   def delete_event_session(livestorm_event_session_id)
-    notify_remaining_ratelimit(RestClient.delete("#{ROOT_URL}/sessions/#{livestorm_event_session_id}", headers))
+    RestClient.delete("#{root_url}/sessions/#{livestorm_event_session_id}", headers)
   end
 
   def post_register_participant(participant_attrs)
     id = participant_attrs.delete(:session_id)
 
     payload = { data: participant_attrs }.to_json
-    notify_remaining_ratelimit(RestClient.post("#{ROOT_URL}/sessions/#{id}/people", payload, headers))
+    RestClient.post("#{root_url}/sessions/#{id}/people", payload, headers)
   end
 
   def get_session(livestorm_session_id)
-    notify_remaining_ratelimit(
-      RestClient::Request.execute(
-        method: :get,
-        url: "#{ROOT_URL}/sessions/#{livestorm_session_id}",
-        headers: headers
-      )
+    RestClient::Request.execute(
+      method: :get,
+      url: "#{root_url}/sessions/#{livestorm_session_id}",
+      headers: headers
     )
   end
 
   def get_session_people(livestorm_session_id)
-    notify_remaining_ratelimit(
-      RestClient::Request.execute(
-        method: :get,
-        url: "#{ROOT_URL}/sessions/#{livestorm_session_id}/people",
-        headers: headers
-      )
+    RestClient::Request.execute(
+      method: :get,
+      url: "#{root_url}/sessions/#{livestorm_session_id}/people",
+      headers: headers
     )
   end
 
   def delete_session_people(livestorm_session_id, email)
-    notify_remaining_ratelimit(
-      RestClient::Request.execute(
-        method: :delete,
-        url: "#{ROOT_URL}/sessions/#{livestorm_session_id}/people?filter[email]=#{email}",
-        headers: headers
-      )
+    RestClient::Request.execute(
+      method: :delete,
+      url: "#{root_url}/sessions/#{livestorm_session_id}/people?filter[email]=#{email}",
+      headers: headers
     )
   end
 
@@ -136,48 +119,40 @@ class LivestormApi
   #
   def get_users(options = {})
     params = { params: options }
-    notify_remaining_ratelimit(
-      RestClient.get("#{ROOT_URL}/users", headers.merge(params))
-    )
+    RestClient.get("#{root_url}/users", headers.merge(params))
   end
 
   def post_user(user_attrs)
     payload = { data: user_attrs }.to_json
 
-    notify_remaining_ratelimit(RestClient.post("#{ROOT_URL}/users", payload, headers))
+    RestClient.post("#{root_url}/users", payload, headers)
   end
 
   # mostly helpful for debugging
   #
   def get_current_user
-    notify_remaining_ratelimit(
-      RestClient.get("#{ROOT_URL}/me", headers)
-    )
+    RestClient.get("#{root_url}/me", headers)
   end
 
   # mostly helpful for debugging
-  #d
+  #
   def get_people
-    notify_remaining_ratelimit(
-      RestClient.get("#{ROOT_URL}/people", headers)
-    )
+    RestClient.get("#{root_url}/people", headers)
   end
 
   # mostly helpful for debugging
   #
   def get_organization
-    notify_remaining_ratelimit(
-      RestClient.get("#{ROOT_URL}/organization", headers)
-    )
+    RestClient.get("#{root_url}/organization", headers)
   end
 
   def get_recordings(livestorm_session_id)
-    RestClient.get("#{ROOT_URL}/sessions/#{livestorm_session_id}/recordings", headers)
+    RestClient.get("#{root_url}/sessions/#{livestorm_session_id}/recordings", headers)
   end
 
   private
 
-  attr_reader :api_token
+  attr_reader :api_token, :root_url
 
   def headers
     @headers ||= {
@@ -185,27 +160,5 @@ class LivestormApi
       "Content-Type" => "application/vnd.api+json",
       "Accept" => "application/vnd.api+json"
     }
-  end
-
-  def notify_remaining_ratelimit(response)
-    message = get_log_message response
-    if message
-      if defined?(Honeybadger)
-        Honeybadger.notify(message)
-      else
-        Logger.new(STDOUT).warn(message)
-      end
-    end
-
-    response
-  end
-
-  def get_log_message response
-    remaining = response.headers[:ratelimit_monthly_remaining].to_f
-    total = response.headers[:ratelimit_monthly_limit].to_f
-
-    return "Livestorm perodic limit is unidentified.  remaining: #{remaining}, total: #{total}." if remaining.zero? && total.zero?
-
-    "Livestorm periodic limit nearly reached!" if (remaining / total) < 0.2
   end
 end

--- a/livestorm_ruby.gemspec
+++ b/livestorm_ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "livestorm_ruby"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["harsh-materialplusio"]
   spec.email         = ["harshwardhan.rathore@materialplus.io"]
   spec.summary       = %q{Livestorm API methods for Rails}
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = Dir['{lib}/**/*'] + ['README.md', 'LICENSE.md']
-  
+
   spec.add_dependency 'rest-client'
 
   spec.add_development_dependency 'minitest'


### PR DESCRIPTION
add optional root_url to initializer

we can remove the rate limiting since it depends on Logger and Honeybadger.  that logic can be added in to the client that uses this.

adding an optional root_url will allow us to point to local or staged servers that "stand-in" for livestorm to facilitate development without having to rely on the real service