### PR TITLE
allow LivestormApi to be configured in initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ client = LivestormApi.new(
 )
 ```
 
+## Running tests
+```
+> rake test
+```
+
 
 ### Get Event People
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ client = LivestormApi.new(
 Returns [event people](https://api.livestorm.co/v1/events/id/people).
 
 ```ruby
-data = client.get_event_people(livestorm_event_id) # => 
+data = client.get_event_people(livestorm_event_id) # =>
 
 #sample response =>
 {

--- a/lib/livestorm_api.rb
+++ b/lib/livestorm_api.rb
@@ -9,26 +9,54 @@ class LivestormApi
   # are running low.
   # See: https://developers.livestorm.co/docs/rate-limits-and-quotas
   #
-  #
-  def initialize(api_token:, root_url: 'https://api.livestorm.co/v1')
+  @root_url = 'https://api.livestorm.co/v1'
+  @after_request_hook = nil
+
+  # This method is OPTIONAL and used to configure the LivestormApi class
+  # Specifically:
+  # root_url (string) set the root url for the Livestorm API
+  #   defaults to 'https://api.livestorm.co/v1'
+  # after_request_hook (proc) to be called after each request
+  #   The proc takes a single argument, the response from the request and is
+  #   guaranteed to be called after each request
+  #   with the result that the response is always returned
+  #   example:
+  #   LivestormApi.config do |config|
+  #    config.after_request_hook = ->(response) { #do something with response }
+  #   end
+
+  def self.config
+    yield self
+  end
+
+  class << self
+    attr_accessor :after_request_hook, :root_url
+  end
+
+  def initialize(api_token:)
     @api_token = api_token
-    @root_url = root_url
   end
 
   def get_ping
-    RestClient.get("#{root_url}/ping", headers)
+    response = RestClient.get("#{self.class.root_url}/ping", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_events(options = {})
     params = { params: options }
-    RestClient::Request.execute(method: :get, url: "#{root_url}/events", headers: headers.merge(params))
+    response = RestClient::Request.execute(method: :get, url: "#{self.class.root_url}/events", headers: headers.merge(params))
+  ensure
+    run_after_request_hook(response)
   end
 
   # requires an event Hash
   #
   def post_event(event)
     payload = { data: event }.to_json
-    RestClient.post("#{root_url}/events", payload, headers)
+    response = RestClient.post("#{self.class.root_url}/events", payload, headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   # requires an event Hash
@@ -36,80 +64,104 @@ class LivestormApi
   def patch_event(event)
     id = event.delete(:id)
     payload = { data: event }.to_json
-    RestClient.patch("#{root_url}/events/#{id}", payload, headers)
+    response = RestClient.patch("#{self.class.root_url}/events/#{id}", payload, headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_event(livestorm_event_id)
-    RestClient.get("#{root_url}/events/#{livestorm_event_id}", headers)
+    response = RestClient.get("#{self.class.root_url}/events/#{livestorm_event_id}", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_event_people(livestorm_event_id, options = {})
     params = { params: options }
-    RestClient::Request.execute(
+    response = RestClient::Request.execute(
       method: :get,
-      url: "#{root_url}/events/#{livestorm_event_id}/people",
+      url: "#{self.class.root_url}/events/#{livestorm_event_id}/people",
       headers: headers.merge(params)
     )
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_event_person(livestorm_event_id:, livestorm_person_id:)
-    RestClient.get("#{root_url}/events/#{livestorm_event_id}/people/#{livestorm_person_id}", headers)
+    response = RestClient.get("#{self.class.root_url}/events/#{livestorm_event_id}/people/#{livestorm_person_id}", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_event_sessions(livestorm_event_id, options = {})
     params = { params: options }
-    RestClient::Request.execute(
+    response = RestClient::Request.execute(
       method: :get,
-      url: "#{root_url}/events/#{livestorm_event_id}/sessions",
+      url: "#{self.class.root_url}/events/#{livestorm_event_id}/sessions",
       headers: headers.merge(params)
     )
+  ensure
+    run_after_request_hook(response)
   end
 
   def post_event_session(session_attrs)
     livestorm_event_id = session_attrs.delete(:livestorm_event_id)
     payload = { data: session_attrs }.to_json
-    RestClient.post("#{root_url}/events/#{livestorm_event_id}/sessions", payload, headers)
+    response = RestClient.post("#{self.class.root_url}/events/#{livestorm_event_id}/sessions", payload, headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def patch_event_session(session_attrs)
     id = session_attrs.delete(:id)
     payload = { data: session_attrs }.to_json
-    RestClient.patch("#{root_url}/sessions/#{id}", payload, headers)
+    response = RestClient.patch("#{self.class.root_url}/sessions/#{id}", payload, headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def delete_event_session(livestorm_event_session_id)
-    RestClient.delete("#{root_url}/sessions/#{livestorm_event_session_id}", headers)
+    response = RestClient.delete("#{self.class.root_url}/sessions/#{livestorm_event_session_id}", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def post_register_participant(participant_attrs)
     id = participant_attrs.delete(:session_id)
 
     payload = { data: participant_attrs }.to_json
-    RestClient.post("#{root_url}/sessions/#{id}/people", payload, headers)
+    response = RestClient.post("#{self.class.root_url}/sessions/#{id}/people", payload, headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_session(livestorm_session_id)
-    RestClient::Request.execute(
+    response = RestClient::Request.execute(
       method: :get,
-      url: "#{root_url}/sessions/#{livestorm_session_id}",
+      url: "#{self.class.root_url}/sessions/#{livestorm_session_id}",
       headers: headers
     )
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_session_people(livestorm_session_id)
-    RestClient::Request.execute(
+    response = RestClient::Request.execute(
       method: :get,
-      url: "#{root_url}/sessions/#{livestorm_session_id}/people",
+      url: "#{self.class.root_url}/sessions/#{livestorm_session_id}/people",
       headers: headers
     )
+  ensure
+    run_after_request_hook(response)
   end
 
   def delete_session_people(livestorm_session_id, email)
-    RestClient::Request.execute(
+    response = RestClient::Request.execute(
       method: :delete,
-      url: "#{root_url}/sessions/#{livestorm_session_id}/people?filter[email]=#{email}",
+      url: "#{self.class.root_url}/sessions/#{livestorm_session_id}/people?filter[email]=#{email}",
       headers: headers
     )
+  ensure
+    run_after_request_hook(response)
   end
 
   # options:
@@ -119,40 +171,52 @@ class LivestormApi
   #
   def get_users(options = {})
     params = { params: options }
-    RestClient.get("#{root_url}/users", headers.merge(params))
+    response = RestClient.get("#{self.class.root_url}/users", headers.merge(params))
+  ensure
+    run_after_request_hook(response)
   end
 
   def post_user(user_attrs)
     payload = { data: user_attrs }.to_json
 
-    RestClient.post("#{root_url}/users", payload, headers)
+    response = RestClient.post("#{self.class.root_url}/users", payload, headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   # mostly helpful for debugging
   #
   def get_current_user
-    RestClient.get("#{root_url}/me", headers)
+    response = RestClient.get("#{self.class.root_url}/me", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   # mostly helpful for debugging
   #
   def get_people
-    RestClient.get("#{root_url}/people", headers)
+    response = RestClient.get("#{self.class.root_url}/people", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   # mostly helpful for debugging
   #
   def get_organization
-    RestClient.get("#{root_url}/organization", headers)
+    response = RestClient.get("#{self.class.root_url}/organization", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   def get_recordings(livestorm_session_id)
-    RestClient.get("#{root_url}/sessions/#{livestorm_session_id}/recordings", headers)
+    response = RestClient.get("#{self.class.root_url}/sessions/#{livestorm_session_id}/recordings", headers)
+  ensure
+    run_after_request_hook(response)
   end
 
   private
 
-  attr_reader :api_token, :root_url
+  attr_reader :api_token
 
   def headers
     @headers ||= {
@@ -160,5 +224,14 @@ class LivestormApi
       "Content-Type" => "application/vnd.api+json",
       "Accept" => "application/vnd.api+json"
     }
+  end
+
+  # runs the after_request_hook if it is set
+  # always returns the response
+  #
+  def run_after_request_hook(response)
+    self.class.after_request_hook.call(response) if self.class.after_request_hook
+
+    response
   end
 end

--- a/livestorm_ruby.gemspec
+++ b/livestorm_ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "livestorm_ruby"
-  spec.version       = "0.2.0"
+  spec.version       = "0.3.0"
   spec.authors       = ["harsh-materialplusio"]
   spec.email         = ["harshwardhan.rathore@materialplus.io"]
   spec.summary       = %q{Livestorm API methods for Rails}

--- a/test/lib/livestorm_api_delete_event_session_test.rb
+++ b/test/lib/livestorm_api_delete_event_session_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 
 class LivestormApiDeleteEventSessionTest < ActiveSupport::TestCase
   setup do
-    stub_request(:delete, "#{LivestormApi::ROOT_URL}/sessions/some-id").to_return(status: 204, body: '{}')
+    stub_request(:delete, "#{LivestormApi.root_url}/sessions/some-id").to_return(status: 204, body: '{}')
   end
 
   should "return successful response" do

--- a/test/lib/livestorm_api_delete_session_people_test.rb
+++ b/test/lib/livestorm_api_delete_session_people_test.rb
@@ -2,12 +2,12 @@
 
 require_relative "../test_helper"
 
-class LivestormApiPostRegisterParticipantTest <ActiveSupport::TestCase
+class LivestormApiDeleteSessionPeopleTest <ActiveSupport::TestCase
   setup do
     @response = FactoryBot.create(:livestorm_participant).to_json
     @some_id = 'abc'
     @email = 'some@bodyoncetold.me'
-    stub_request(:delete, "#{LivestormApi::ROOT_URL}/sessions/#{@some_id}/people?filter[email]=#{@email}").to_return(status: 200, body: @response)
+    stub_request(:delete, "#{LivestormApi.root_url}/sessions/#{@some_id}/people?filter[email]=#{@email}").to_return(status: 200, body: @response)
   end
 
   should 'return successful response' do
@@ -17,4 +17,3 @@ class LivestormApiPostRegisterParticipantTest <ActiveSupport::TestCase
     assert_equal(@response, result.body)
   end
 end
-

--- a/test/lib/livestorm_api_get_event_people_test.rb
+++ b/test/lib/livestorm_api_get_event_people_test.rb
@@ -7,7 +7,7 @@ class LivestormApiGetEventPeopleTest < ActiveSupport::TestCase
   setup do
     @response = FactoryBot.create(:livestorm_people_response).to_json
     @livestorm_event_id = 'some-id'
-    stub_request(:get, "#{LivestormApi::ROOT_URL}/events/#{@livestorm_event_id}/people").to_return(status: 200, body: @response)
+    stub_request(:get, "#{LivestormApi.root_url}/events/#{@livestorm_event_id}/people").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do

--- a/test/lib/livestorm_api_get_event_person_test.rb
+++ b/test/lib/livestorm_api_get_event_person_test.rb
@@ -8,7 +8,7 @@ class LivestormApiGetEventPersonTest < ActiveSupport::TestCase
     @response = FactoryBot.create(:livestorm_people_response).to_json
     @livestorm_event_id = 'some-id'
     @livestorm_person_id = 'some-person-id'
-    stub_request(:get, "#{LivestormApi::ROOT_URL}/events/#{@livestorm_event_id}/people/#{@livestorm_person_id}").to_return(status: 200, body: @response)
+    stub_request(:get, "#{LivestormApi.root_url}/events/#{@livestorm_event_id}/people/#{@livestorm_person_id}").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do

--- a/test/lib/livestorm_api_get_event_sessions_test.rb
+++ b/test/lib/livestorm_api_get_event_sessions_test.rb
@@ -7,7 +7,7 @@ class LivestormApiGetEventSessionsTest < ActiveSupport::TestCase
   setup do
     @response = FactoryBot.create(:livestorm_sessions_response).to_json
     @livestorm_event_id = 'some-id'
-    stub_request(:get, "#{LivestormApi::ROOT_URL}/events/#{@livestorm_event_id}/sessions").to_return(status: 200, body: @response)
+    stub_request(:get, "#{LivestormApi.root_url}/events/#{@livestorm_event_id}/sessions").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do

--- a/test/lib/livestorm_api_get_event_test.rb
+++ b/test/lib/livestorm_api_get_event_test.rb
@@ -11,7 +11,7 @@ class LivestormApiGetEventTest < ActiveSupport::TestCase
   context "without params" do
     setup do
       @livestorm_event_id = 'some-id'
-      stub_request(:get, "#{LivestormApi::ROOT_URL}/events/#{@livestorm_event_id}").to_return(status: 200, body: @response)
+      stub_request(:get, "#{LivestormApi.root_url}/events/#{@livestorm_event_id}").to_return(status: 200, body: @response)
     end
 
     should "return successful response" do

--- a/test/lib/livestorm_api_get_events_test.rb
+++ b/test/lib/livestorm_api_get_events_test.rb
@@ -10,7 +10,7 @@ class LivestormApiGetEventsTest < ActiveSupport::TestCase
 
   context "without params" do
     setup do
-      stub_request(:get, "#{LivestormApi::ROOT_URL}/events").to_return(status: 200, body: @response)
+      stub_request(:get, "#{LivestormApi.root_url}/events").to_return(status: 200, body: @response)
     end
 
     should "return successful response" do
@@ -30,7 +30,7 @@ class LivestormApiGetEventsTest < ActiveSupport::TestCase
     #
     setup do
       @query_params = {"page[number]" => 1}
-      stub_request(:get, "#{LivestormApi::ROOT_URL}/events").with(query: @query_params).to_return(status: 200)
+      stub_request(:get, "#{LivestormApi.root_url}/events").with(query: @query_params).to_return(status: 200)
     end
 
     should "return successful response" do

--- a/test/lib/livestorm_api_get_ping_test.rb
+++ b/test/lib/livestorm_api_get_ping_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 
 class LivestormApiGetPingTest < ActiveSupport::TestCase
   setup do
-    stub_request(:get, "#{LivestormApi::ROOT_URL}/ping").to_return(status: 200, body: "{}")
+    stub_request(:get, "#{LivestormApi.root_url}/ping").to_return(status: 200, body: "{}")
   end
 
   should "return successful response" do
@@ -11,22 +11,5 @@ class LivestormApiGetPingTest < ActiveSupport::TestCase
 
     assert_equal(200, result.code)
     assert_equal("{}", result.body)
-  end
-
-  context "when we have less than 1000 remaining requests" do
-    setup do
-      return_headers = {"ratelimit_monthly_remaining" => 999, "ratelimit_monthly_limit" => 5000}
-      stub_request(:get, "#{LivestormApi::ROOT_URL}/ping").to_return(status: 200, body: "{}", headers: return_headers)
-    end
-
-    should "log warning" do
-      mock_logger = Minitest::Mock.new
-      mock_logger.expect(:warn, nil, ['Livestorm periodic limit nearly reached!'])
-      Logger.stub(:new, mock_logger) do
-        LivestormApi.new(api_token: 'foo').get_ping
-      end
-  
-      mock_logger.verify
-    end
   end
 end

--- a/test/lib/livestorm_api_get_recordings_test.rb
+++ b/test/lib/livestorm_api_get_recordings_test.rb
@@ -3,11 +3,11 @@
 require_relative "../test_helper"
 
 
-class LivestormApiGetUsersTest < ActiveSupport::TestCase
+class LivestormApiGetRecordingsTest < ActiveSupport::TestCase
   setup do
     @response = FactoryBot.create(:livestorm_recordings_response).to_json
     @session_id = 'abc'
-    stub_request(:get, "#{LivestormApi::ROOT_URL}/sessions/#{@session_id}/recordings").to_return(status: 200, body: @response)
+    stub_request(:get, "#{LivestormApi.root_url}/sessions/#{@session_id}/recordings").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do

--- a/test/lib/livestorm_api_get_users_test.rb
+++ b/test/lib/livestorm_api_get_users_test.rb
@@ -5,7 +5,7 @@ require_relative "../test_helper"
 class LivestormApiGetUsersTest < ActiveSupport::TestCase
   setup do
     @response = FactoryBot.create(:livestorm_users_response).to_json
-    stub_request(:get, "#{LivestormApi::ROOT_URL}/users").to_return(status: 200, body: @response)
+    stub_request(:get, "#{LivestormApi.root_url}/users").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do
@@ -17,7 +17,7 @@ class LivestormApiGetUsersTest < ActiveSupport::TestCase
 
   context 'when filter option is passed' do
     setup do
-      stub_request(:get, "#{LivestormApi::ROOT_URL}/users?filter[role]=host").to_return(status: 200, body: @response)
+      stub_request(:get, "#{LivestormApi.root_url}/users?filter[role]=host").to_return(status: 200, body: @response)
     end
 
     should "return successful response" do

--- a/test/lib/livestorm_api_patch_event_session_test.rb
+++ b/test/lib/livestorm_api_patch_event_session_test.rb
@@ -7,7 +7,7 @@ class LivestormApiPatchEventSessionTest < ActiveSupport::TestCase
     video_chat_session = FactoryBot.create(:video_chat_session, provider_id: 'provider-id')
     @response = FactoryBot.create(:livestorm_session_response).to_json
     @payload = FactoryBot.create(:video_chat_session_payload, video_chat_session: video_chat_session)
-    stub_request(:patch, "#{LivestormApi::ROOT_URL}/sessions/#{video_chat_session.provider_id}").to_return(status: 200, body: @response)
+    stub_request(:patch, "#{LivestormApi.root_url}/sessions/#{video_chat_session.provider_id}").to_return(status: 200, body: @response)
   end
 
   should 'return successful response' do

--- a/test/lib/livestorm_api_patch_event_test.rb
+++ b/test/lib/livestorm_api_patch_event_test.rb
@@ -7,7 +7,7 @@ class LivestormApiPatchEventTest < ActiveSupport::TestCase
     video_chat = FactoryBot.create(:video_chat, provider_id: 'provider-id')
     @response = FactoryBot.create(:livestorm_event_response).to_json
     @payload = FactoryBot.create(:video_chat_payload, video_chat: video_chat, video_chat_settings: {})
-    stub_request(:patch, "#{LivestormApi::ROOT_URL}/events/#{video_chat.provider_id}").to_return(status: 200, body: @response)
+    stub_request(:patch, "#{LivestormApi.root_url}/events/#{video_chat.provider_id}").to_return(status: 200, body: @response)
   end
 
   should 'return successful response' do

--- a/test/lib/livestorm_api_post_event_session_test.rb
+++ b/test/lib/livestorm_api_post_event_session_test.rb
@@ -14,7 +14,7 @@ class LivestormApiPostEventSessionsTest < ActiveSupport::TestCase
         timezone: 'America/New_York'
       }
     }
-    stub_request(:post, "#{LivestormApi::ROOT_URL}/events/livestorm-event-id/sessions").to_return(status: 200, body: @response)
+    stub_request(:post, "#{LivestormApi.root_url}/events/livestorm-event-id/sessions").to_return(status: 200, body: @response)
   end
 
   should 'return successful response' do

--- a/test/lib/livestorm_api_post_event_test.rb
+++ b/test/lib/livestorm_api_post_event_test.rb
@@ -26,7 +26,7 @@ class LivestormApiPostEventTest < ActiveSupport::TestCase
       }
     }
     @response = FactoryBot.create(:livestorm_events_response).to_json
-    stub_request(:post, "#{LivestormApi::ROOT_URL}/events").to_return(status: 200, body: @response)
+    stub_request(:post, "#{LivestormApi.root_url}/events").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do

--- a/test/lib/livestorm_api_post_register_participant_test.rb
+++ b/test/lib/livestorm_api_post_register_participant_test.rb
@@ -17,7 +17,7 @@ class LivestormApiPostRegisterParticipantTest <ActiveSupport::TestCase
       }
     }
     @response = FactoryBot.create(:livestorm_participant).to_json
-    stub_request(:post, "#{LivestormApi::ROOT_URL}/sessions/#{video_chat_session.provider_id}/people").to_return(status: 200, body: @response)
+    stub_request(:post, "#{LivestormApi.root_url}/sessions/#{video_chat_session.provider_id}/people").to_return(status: 200, body: @response)
   end
 
   should 'return successful response' do

--- a/test/lib/livestorm_api_post_user_test.rb
+++ b/test/lib/livestorm_api_post_user_test.rb
@@ -13,7 +13,7 @@ class LivestormApiPostUsertest < ActiveSupport::TestCase
       }
     }
     @response = FactoryBot.create(:livestorm_users_response).to_json
-    stub_request(:post, "#{LivestormApi::ROOT_URL}/users").to_return(status: 200, body: @response)
+    stub_request(:post, "#{LivestormApi.root_url}/users").to_return(status: 200, body: @response)
   end
 
   should "return successful response" do


### PR DESCRIPTION
this will let us set the root_url and an after_request hook when the class is configured